### PR TITLE
Pod count as load metrics in BurstMetrics Service

### DIFF
--- a/burst/src/Controllers/BurstMetricsController.cs
+++ b/burst/src/Controllers/BurstMetricsController.cs
@@ -39,9 +39,17 @@ namespace Ngsa.BurstService.Controllers
             // But we can control what to output if we do null
             // TODO: Set the default value from appsettings.json
 
-            string targetLoad = hpaMetrics?.TargetLoad?.ToString() ?? "-1";
-            string currentLoad = hpaMetrics?.CurrentLoad?.ToString() ?? "-1";
-            string maxLoad = hpaMetrics?.MaxLoad?.ToString() ?? "-1";
+            if (hpaMetrics == null)
+            {
+                // Means we don't have all the values available
+                return NoContent();
+            }
+
+            // hpaMetrics was Null checked, so it should have all the values
+            // Checking nullable would be redundant
+            string targetLoad = hpaMetrics.TargetLoad.ToString();
+            string currentLoad = hpaMetrics.CurrentLoad.ToString();
+            string maxLoad = hpaMetrics.MaxLoad.ToString();
 
             // Get the CPU Target
             logger.LogDebug("Max: {}, Target: {}, Cur: {},", maxLoad, targetLoad, currentLoad);

--- a/burst/src/Controllers/BurstMetricsController.cs
+++ b/burst/src/Controllers/BurstMetricsController.cs
@@ -39,14 +39,15 @@ namespace Ngsa.BurstService.Controllers
             // But we can control what to output if we do null
             // TODO: Set the default value from appsettings.json
 
-            string cpuTarget = hpaMetrics?.TargetCPULoad?.ToString() ?? "-1";
-            string cpuCurrent = hpaMetrics?.CurrentCPULoad?.ToString() ?? "-1";
+            string targetLoad = hpaMetrics?.TargetLoad?.ToString() ?? "-1";
+            string currentLoad = hpaMetrics?.CurrentLoad?.ToString() ?? "-1";
+            string maxLoad = hpaMetrics?.MaxLoad?.ToString() ?? "-1";
 
             // Get the CPU Target
-            logger.LogDebug("Target: {}, Cur CPU: {}", cpuTarget, cpuCurrent);
+            logger.LogDebug("Max: {}, Target: {}, Cur: {},", maxLoad, targetLoad, currentLoad);
 
             // Console.WriteLine($"{DateTime.Now:s}  {Request.Path.ToString()}");
-            return Ok($"service={ns}/{deployment}, current-load={cpuCurrent}, target-load={cpuTarget}, max-load=85");
+            return Ok($"service={ns}/{deployment}, current-load={currentLoad}, target-load={targetLoad}, max-load={maxLoad}");
         }
     }
 }

--- a/burst/src/K8sApi/K8sHPAMetrics.cs
+++ b/burst/src/K8sApi/K8sHPAMetrics.cs
@@ -5,7 +5,8 @@ namespace Ngsa.BurstService.K8sApi
 {
     public class K8sHPAMetrics
     {
-        public int? CurrentCPULoad { get; internal set; } = null;
-        public int? TargetCPULoad { get; internal set; } = null;
+        public int? CurrentLoad { get; internal set; } = null;
+        public int? TargetLoad { get; internal set; } = null;
+        public int? MaxLoad { get; internal set; } = null;
     }
 }

--- a/burst/src/K8sApi/K8sHPAMetricsService.cs
+++ b/burst/src/K8sApi/K8sHPAMetricsService.cs
@@ -13,6 +13,7 @@ namespace Ngsa.BurstService.K8sApi
 {
     public class K8sHPAMetricsService : IHostedService, IDisposable, IK8sHPAMetricsService
     {
+        private const double TargetPercent = 0.8;
         private readonly ILogger<K8sHPAMetricsService> logger;
         private readonly IKubernetes client;
         private Timer timer;
@@ -61,11 +62,25 @@ namespace Ngsa.BurstService.K8sApi
                 {
                     if (hpa.Namespace().Equals(ns) && hpa.Name().Equals(deployment))
                     {
-                        // Get the Target CPU load
-                        hpaMetrics.TargetCPULoad = GetTargetCpuLoad(hpa);
+                        try
+                        {
+                            // Get the Target CPU load
+                            hpaMetrics.MaxLoad = GetMaxLoad(hpa);
 
-                        // Get the current CPU load
-                        hpaMetrics.CurrentCPULoad = GetCurrentCpuLoad(hpa);
+                            // Get the current CPU load
+                            hpaMetrics.CurrentLoad = GetCurrentLoad(hpa);
+                            hpaMetrics.TargetLoad = (int?)Math.Floor(hpaMetrics.MaxLoad.GetValueOrDefault() * TargetPercent);
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogWarning(ex.Message);
+                        }
+
+                        if (hpaMetrics.TargetLoad == 0)
+                        {
+                            hpaMetrics.TargetLoad = hpaMetrics.MaxLoad;
+                        }
+
                         return hpaMetrics;
                     }
                 }
@@ -133,43 +148,36 @@ namespace Ngsa.BurstService.K8sApi
             }
         }
 
-        private int? GetCurrentCpuLoad(V2beta2HorizontalPodAutoscaler hpa)
+        private int GetCurrentLoad(V2beta2HorizontalPodAutoscaler hpa)
         {
             // Check if we created HPA but but don't have a metrics server
-            if (hpa?.Status?.CurrentMetrics != null)
+            int currReplicas;
+            if (hpa?.Status != null)
             {
-                foreach (V2beta2MetricStatus m in hpa.Status.CurrentMetrics)
-                {
-                    // We're interested in CPU metrics
-                    if (m.Resource.Name == "cpu")
-                    {
-                        return m.Resource.Current.AverageUtilization;
-                    }
-                }
+                currReplicas = hpa.Status.CurrentReplicas;
+            }
+            else
+            {
+                throw new Exception("Cannot get HPA metrics because hpa is null");
             }
 
-            logger.LogWarning("Cannot get HPA metrics (probable cause: no metrics server)");
-
-            return null;
+            return currReplicas;
         }
 
-        private int? GetTargetCpuLoad(V2beta2HorizontalPodAutoscaler hpa)
+        private int GetMaxLoad(V2beta2HorizontalPodAutoscaler hpa)
         {
+            int maxReplicas;
             // Check if we created HPA but didn't set any CPU Target
-            if (hpa?.Spec?.Metrics != null)
+            if (hpa?.Spec != null)
             {
-                foreach (V2beta2MetricSpec m in hpa.Spec.Metrics)
-                {
-                    // We're interested in CPU metrics
-                    if (m.Resource.Name == "cpu")
-                    {
-                        return m.Resource.Target.AverageUtilization;
-                    }
-                }
+                maxReplicas = hpa.Spec.MaxReplicas;
+            }
+            else
+            {
+                throw new Exception("Cannot get HPA Spec because hpa is null");
             }
 
-            logger.LogWarning("HPA Spec is not set");
-            return null;
+            return maxReplicas;
         }
     }
 }

--- a/burst/src/K8sApi/K8sHPAMetricsService.cs
+++ b/burst/src/K8sApi/K8sHPAMetricsService.cs
@@ -167,6 +167,7 @@ namespace Ngsa.BurstService.K8sApi
         private int GetMaxLoad(V2beta2HorizontalPodAutoscaler hpa)
         {
             int maxReplicas;
+
             // Check if we created HPA but didn't set any CPU Target
             if (hpa?.Spec != null)
             {


### PR DESCRIPTION
# Type of PR

- [X] Code changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Threw exception manually to test `204-NoContent`

## Purpose of PR

Change the load type from CPU metrics to Pod count from HPA.

## Does this introduce a breaking change

- [X] YES
- [ ] NO

Previously BurstMetrics Service returned CPU percentage as load metrics.
With this PR, BurstMetrics will return POD count as load metrics.

## Validation

- [X] Ran local tests and integration tests
- [X] Update documentation or issue referenced above

## Issues Closed

- Closes https://github.com/retaildevcrews/wcnp/issues/280
- Closes https://github.com/retaildevcrews/wcnp/issues/294
- Closes https://github.com/retaildevcrews/wcnp/issues/299