### PR TITLE
HPA with custom metrics from Prometheus

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
 	// Port Labels
 	"portsAttributes": {
 		"30080": { "label": "NGSA-Memory NodePort" },
-		"30081": { "label": "Burst Metric Serivce NodePort" }
+		"30081": { "label": "Burst Metric Serivce NodePort" },
+		"30082": { "label": "Prometheus UI NodePort" }
 	},
 	// Set container specific settings
 
@@ -37,6 +38,8 @@
 		"humao.rest-client",
 		"serayuzgur.crates",
 		"visualstudioexptteam.vscodeintellicode",
+		"oderwat.indent-rainbow",
+		"eamodio.gitlens",
 		"ms-dotnettools.csharp" // Remove when burst svc is separated
 	],
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,6 @@
 		"humao.rest-client",
 		"serayuzgur.crates",
 		"visualstudioexptteam.vscodeintellicode",
-		"oderwat.indent-rainbow",
 		"eamodio.gitlens",
 		"ms-dotnettools.csharp" // Remove when burst svc is separated
 	],

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,25 @@ clean :
 	@kubectl delete --ignore-not-found cm burst-wasm-filter
 
 test :
-	# run a 60 second test
-	@cd deploy/loderunner && webv -s http://localhost:30080/ -f benchmark.json -r -l 5 --duration 60
+	# run a timed test ('$(seconds)' seconds)
+	@test "$(seconds)" \
+		&& cd deploy/loderunner \
+		&& webv -s http://localhost:30080/ -f benchmark.json -v -s -r -l 5 --duration $(seconds) \
+		|| echo "usage: make $@ seconds=number\ne.g.   make $@ seconds=60"
+
+prom-adapter-hpa :
+	# Add and update prometheus adapter helm
+	@helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+	@helm repo update
+	# Deploy prometheus
+	@kubectl create ns monitoring
+	@kubectl apply -f deploy/prometheus/prometheus.yaml
+	# Deploy prometheus adapter, it'll take a min or two
+	@helm upgrade --install -n monitoring prom-metrics-adapter -f deploy/prometheus/prom-adapter-helm-values.yaml prometheus-community/prometheus-adapter --wait
+	# Recreate HPA with custom metrics
+	@kubectl apply -f deploy/prometheus/hpa-custom-metrics.yaml
+	# Deploy sample constant load
+	@kubectl apply -f deploy/loderunner/loderunner.yaml
 
 check-metrics :
 	# retrieve current values from metrics server

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ make check
 
 ```bash
 
-make test &
+# Run a 120 seconds test in the background
+make test seconds=120 > /dev/null 2>&1 &
 
 # press enter a few times to clear background output
 
@@ -54,6 +55,30 @@ kubectl get pods
 ```
 
 - The `HPA` will scale back to one pod in a few minutes
+
+## Use custom metrics from prometheus
+
+NgsaRequestsPerSecond is exposed to the HPA as a custom metrics.
+
+NgsaRequestsPerSecond is used in addition to CPU metrics to scaled HPA.
+
+```bash
+
+# Deploy prometheus, prometheus adapter and recreate HPA with custom metrics
+# It will take a min or two
+make prom-adapter-hpa
+
+# Watch for the new custom metrics to be avaialbe
+kubectl get hpa ngsa --watch
+# Should output similar lines below (otherwise one or two would be Unknown)
+## NAME   REFERENCE         TARGETS           MINPODS   MAXPODS   REPLICAS   AGE
+## ngsa   Deployment/ngsa   499m/50, 2%/50%   1         2         2          14m
+
+# Press Ctrl+C to stop watch
+
+```
+
+Now follow [Add Load](#add-load) section to apply load to the ngsa app.
 
 ## Request Flow
 

--- a/clusteradm/Makefile
+++ b/clusteradm/Makefile
@@ -34,9 +34,6 @@ all : delete
 	@/usr/local/istio/bin/istioctl install --set profile=demo -y
 	@kubectl label namespace default istio-injection=enabled --overwrite
 
-	# deploy metrics server
-	@kubectl apply -f ../deploy/metrics
-
 	# add config map
 	@kubectl create cm burst-wasm-filter --from-file=../burst_header.wasm
 

--- a/deploy/k3d/k3d.yaml
+++ b/deploy/k3d/k3d.yaml
@@ -13,6 +13,9 @@ ports:
 - port: 30081:30081
   nodeFilters:
   - server:0
+- port: 30082:30082
+  nodeFilters:
+  - server:0
 options:
   k3d:
     wait: true

--- a/deploy/k3d/k3d.yaml
+++ b/deploy/k3d/k3d.yaml
@@ -1,4 +1,4 @@
-apiVersion: k3d.io/v1alpha3
+apiVersion: k3d.io/v1alpha4
 kind: Simple
 servers: 1
 network: k3d

--- a/deploy/metrics/components.yaml
+++ b/deploy/metrics/components.yaml
@@ -101,10 +101,8 @@ metadata:
   namespace: kube-system
 spec:
   ports:
-  - name: https
-    port: 443
+  - port: 443
     protocol: TCP
-    targetPort: https
   selector:
     k8s-app: metrics-server
 ---
@@ -141,19 +139,18 @@ spec:
           failureThreshold: 3
           httpGet:
             path: /livez
-            port: https
+            port: 443
             scheme: HTTPS
           periodSeconds: 10
         name: metrics-server
         ports:
         - containerPort: 443
-          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /readyz
-            port: https
+            port: 443
             scheme: HTTPS
           initialDelaySeconds: 20
           periodSeconds: 10

--- a/deploy/metrics/components.yaml
+++ b/deploy/metrics/components.yaml
@@ -36,11 +36,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   - nodes
-  - nodes/stats
-  - namespaces
-  - configmaps
   verbs:
   - get
   - list
@@ -101,8 +104,10 @@ metadata:
   namespace: kube-system
 spec:
   ports:
-  - port: 443
+  - name: https
+    port: 443
     protocol: TCP
+    targetPort: https
   selector:
     k8s-app: metrics-server
 ---
@@ -128,29 +133,29 @@ spec:
       containers:
       - args:
         - --cert-dir=/tmp
-        - --secure-port=443
+        - --secure-port=4443
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
-        - --kubelet-insecure-tls
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
             path: /livez
-            port: 443
+            port: https
             scheme: HTTPS
           periodSeconds: 10
         name: metrics-server
         ports:
-        - containerPort: 443
+        - containerPort: 4443
+          name: https
           protocol: TCP
         readinessProbe:
           failureThreshold: 3
           httpGet:
             path: /readyz
-            port: 443
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 20
           periodSeconds: 10
@@ -159,6 +164,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1000

--- a/deploy/ngsa-memory/ngsa-memory.yaml
+++ b/deploy/ngsa-memory/ngsa-memory.yaml
@@ -39,6 +39,10 @@ spec:
       version: v1
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
       labels:
         app: ngsa
         version: v1

--- a/deploy/prometheus/hpa-custom-metrics.yaml
+++ b/deploy/prometheus/hpa-custom-metrics.yaml
@@ -1,4 +1,9 @@
-apiVersion: autoscaling/v2beta1
+# This is an example HPA which depends on two metrics, one custom and one standard resource
+# See docs specific to v1.22
+# https://v1-22.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/ 
+# TODO: For k8s 1.23+, v2beta* would be deprecated, we should migrate to v2 once we update our k8s
+#######################################################
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: ngsa
@@ -10,7 +15,16 @@ spec:
     kind: Deployment
     name: ngsa
   metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50 # Utilization/Percentage example
   - type: Pods
     pods:
-      metricName: NgsaRequestsPerSecond # Defined in prometheus adapter
-      targetAverageValue: 5 # 5 requests per second
+      metric:
+        name: NgsaRequestsPerSecond # Custom metrics defined in prometheus adapter
+      target:
+        type: AverageValue # Using a direct value example
+        averageValue: 50 # 50 requests per second

--- a/deploy/prometheus/hpa-custom-metrics.yaml
+++ b/deploy/prometheus/hpa-custom-metrics.yaml
@@ -1,0 +1,16 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ngsa
+spec:
+  maxReplicas: 2
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ngsa
+  metrics:
+  - type: Pods
+    pods:
+      metricName: NgsaRequestsPerSecond # Defined in prometheus adapter
+      targetAverageValue: 5 # 5 requests per second

--- a/deploy/prometheus/prom-adapter-helm-values.yaml
+++ b/deploy/prometheus/prom-adapter-helm-values.yaml
@@ -17,5 +17,3 @@ rules:
       matches: "^(.*)AppDuration_count$" # 1st capture group is ${1} in 'as:' section
       as: "${1}RequestsPerSecond"
     metricsQuery: "(sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>))"
-    # metricsQuery: 'NgsaAppDuration_count{code="OK",mode!=""}'
-    # metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>}[30s])) by (<<.GroupBy>>)"

--- a/deploy/prometheus/prom-adapter-helm-values.yaml
+++ b/deploy/prometheus/prom-adapter-helm-values.yaml
@@ -1,0 +1,21 @@
+prometheus:
+    url: http://prometheus-service.monitoring
+    port: 9090
+rules:
+  default: false
+  custom:
+  - seriesQuery: 'NgsaAppDuration_count{kubernetes_namespace!="",kubernetes_pod_name!=""}'
+    resources:
+      overrides:
+        kubernetes_namespace:
+          resource: namespace
+        kubernetes_pod_name:
+          resource: pod
+        # deployment:
+        #   resource: "deployment"
+    name:
+      matches: "^(.*)AppDuration_count$" # 1st capture group is ${1} in 'as:' section
+      as: "${1}RequestsPerSecond"
+    metricsQuery: "(sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>))"
+    # metricsQuery: 'NgsaAppDuration_count{code="OK",mode!=""}'
+    # metricsQuery: "sum(rate(<<.Series>>{<<.LabelMatchers>>}[30s])) by (<<.GroupBy>>)"

--- a/deploy/prometheus/prometheus.yaml
+++ b/deploy/prometheus/prometheus.yaml
@@ -1,0 +1,176 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-cluter-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-role-binding
+
+roleRef:
+  name: prometheus-cluter-role
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: monitoring
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-server-conf
+  labels:
+    name: prometheus-server-conf
+  namespace: monitoring
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+      query_log_file: /prometheus/query.log
+    scrape_configs:
+      - job_name: 'kubernetes-apiservers'
+        kubernetes_sd_configs:
+        - role: endpoints
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+          action: keep
+          regex: default;kubernetes;https
+      - job_name: 'kubernetes-nodes'
+        scheme: https
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        kubernetes_sd_configs:
+        - role: node
+        relabel_configs:
+        - action: labelmap
+          regex: __meta_kubernetes_node_label_(.+)
+        - target_label: __address__
+          replacement: kubernetes.default.svc:443
+        - source_labels: [__meta_kubernetes_node_name]
+          regex: (.+)
+          target_label: __metrics_path__
+          replacement: /api/v1/nodes/${1}/proxy/metrics
+      - job_name: 'kubernetes-pods'
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source_labels: [__meta_kubernetes_namespace]
+          action: replace
+          target_label: kubernetes_namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: kubernetes_pod_name
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+  labels:
+    app: prometheus-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-server
+  template:
+    metadata:
+      labels:
+        app: prometheus-server
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.33.1
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+          ports:
+            - containerPort: 9090
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            defaultMode: 420
+            name: prometheus-server-conf
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-service
+  namespace: monitoring
+  annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port:   '9090'
+spec:
+  selector:
+    app: prometheus-server
+  type: NodePort
+  ports:
+    - port: 9090
+      name: http
+      nodePort: 30082


### PR DESCRIPTION
# Type of PR

- [X] Documentation changes
- [X] Code changes
- [X] Test changes

## Purpose of PR
Add custom metrics capability to HPA using prometheus adapter.

- Automatically deploys prometheus and prometheus-adapter
- Configures all applications for metrics collection
- Creates a new metrics called `NgsaRequestsPerSecond`
- Setup prometheus port and adapter configuration
- Fix latest kubernetes (k3s implementation) metrics deployment issue
  - Latest k3d automatically deploys metrics server
  - Also updated the components.yaml file in case it needs to be deployed
- Added two addons for devexp

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [X] Tests updated and ran successfully
- [X] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/607
- References https://github.com/retaildevcrews/wcnp/issues/596