### PR TITLE
K3d Service LoadBalancer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
 		"30080": { "label": "NGSA-Memory NodePort" },
 		"30081": { "label": "Burst Metric Serivce NodePort" },
 		"30082": { "label": "Prometheus UI NodePort" },
-		"30083": { "label": "Istio Ingress Gateway NodePort" }
+		"30000": { "label": "Istio Ingress Gateway NodePort" }
 	},
 	// Set container specific settings
 

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,6 @@ deploy-gateway : clean build
 	# Waiting for Istio Proxy to redeploy
 	@kubectl wait pod -l app=istio-ingressgateway --namespace=istio-system --for condition=ready --timeout=60s
 
-	# Patch istio-ingressgateway service, will expose the service to nodeport 300083
-	@kubectl patch -n istio-system svc istio-ingressgateway -p '{"spec":{"ports":[{"name":"http2","nodePort":30083,"port":80,"protocol":"TCP","targetPort":8080}]}}'
-
 	# turn the wasm filter on
 	@kubectl apply -f deploy/ngsa-memory/filter-gateway.yaml
 
@@ -59,10 +56,10 @@ check :
 check-gateway :
 	# curl the /memory/healthz endpoint
 	# It won't show the burst headers since the user-agent won't match
-	@curl -i http://localhost:30083/memory/healthz
+	@curl -i http://localhost:30000/memory/healthz
 
 	# this will show the burst header if enabled and deployed at the gateway level
-	@http http://localhost:30083/memory/healthz
+	@http http://localhost:30000/memory/healthz
 
 clean :
 	# delete ngsa sidecar patch and config map

--- a/clusteradm/Makefile
+++ b/clusteradm/Makefile
@@ -13,7 +13,7 @@ delete :
 
 all : delete
 	# build k3d cluster
-	@k3d cluster create ngsa-k3d-cluster --registry-use k3d-registry.localhost:5000 --config ../deploy/k3d/k3d.yaml --k3s-arg "--no-deploy=traefik@server:0" --k3s-arg "--no-deploy=servicelb@server:0"
+	@k3d cluster create ngsa-k3d-cluster --registry-use k3d-registry.localhost:5000 --config ../deploy/k3d/k3d.yaml --k3s-arg "--no-deploy=traefik@server:0"
 
 	# build the WebAssembly
 	rm -f ../burst_header.wasm
@@ -31,8 +31,6 @@ all : delete
 
 	# install istio
 	@/usr/local/istio/bin/istioctl install --set profile=demo -y
-	# Patch the ingressgatway service to expose to NodePort 30083
-	@kubectl patch -n istio-system svc istio-ingressgateway -p '{"spec":{"ports":[{"name":"http2","nodePort":30083,"port":80,"protocol":"TCP","targetPort":8080}]}}'
 
 	@kubectl label namespace default istio-injection=enabled --overwrite
 

--- a/deploy/k3d/k3d.yaml
+++ b/deploy/k3d/k3d.yaml
@@ -16,9 +16,9 @@ ports:
 - port: 30082:30082 # Prometheus NodePort
   nodeFilters:
   - server:0
-- port: 30083:30083 # Istio IngressGateway NodePort
+- port: 30000:80 # Istio IngressGateway LoadBalancer NodePort
   nodeFilters:
-  - server:0
+  - loadbalancer
 options:
   k3d:
     wait: true


### PR DESCRIPTION
# Type of PR

- [X] Code changes

## Purpose of PR
Added k3d Service LoadBalancer.
With this change we don't have to patch the IngressGateway after deployment
A service load balancer will be provided by k3d and istio LB will be port-forwarded automatically

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/672

> **NOTE**: This PR does not implement the Sidecar configuration in WASM. According to our discussion, we are keeping WASM filter readable and easy to understand than to add micro-optimization for Sidecar only (if else in multiple places with added configuration complexity).

> This PR's WASM will run in sidecar and gateway without extra configuration, while Jan's code does need config for Sidecar. His version is a cumulative update to our original sidecar code, where sidecar gets `namespace` and `deployment` from the `EnvoyFilter `configuration.

> While, our version gets bulk hpa data for sidecar and gateway, his version doesn't get bulk cluster data for sidecar making it a little memory optimized. Although, that optimization is trivial and doesn't improve or degrade the HTTP callback performance in anyway.