### PR TITLE
Config validation in wasm, upgrade to v2 hpa api and address other todos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde-humanize-rs = "0.1.1"
 serde_json = "1.0.59"
 wasm-bindgen = "0.2.75"
 wasm-bindgen-test = "0.3.25"
+protobuf = "2.27.1"
 
 [lib]
 crate-type = ["cdylib"]

--- a/burstsvc/burst.tests/Helper/HPAEssentials.cs
+++ b/burstsvc/burst.tests/Helper/HPAEssentials.cs
@@ -28,7 +28,7 @@ namespace Burst.Tests.Helper
                 minReplicas: 1,
                 currentReplicas: 1,
                 targetPercent: .8,
-                apiVersion: "v2beta2"),
+                apiVersion: "v2"),
                 new(
                 deployment: "deploy2",
                 @namespace: "ns2",
@@ -52,7 +52,7 @@ namespace Burst.Tests.Helper
                 minReplicas: 1,
                 currentReplicas: 2,
                 targetPercent: 0,
-                apiVersion: "v2beta2"),
+                apiVersion: "v2"),
             };
         }
 
@@ -67,13 +67,13 @@ namespace Burst.Tests.Helper
             this.ApiVersion = apiVersion;
         }
 
-        public V2beta2HorizontalPodAutoscaler CreateMockHPA()
+        public V2HorizontalPodAutoscaler CreateMockHPA()
         {
-            return new V2beta2HorizontalPodAutoscaler()
+            return new V2HorizontalPodAutoscaler()
             {
                 Metadata = new V1ObjectMeta(name: this.Deployment, namespaceProperty: this.Namespace),
-                Spec = new V2beta2HorizontalPodAutoscalerSpec(maxReplicas: this.MaxReplicas, minReplicas: this.MinReplicas, scaleTargetRef: new V2beta2CrossVersionObjectReference(kind: "Deployment", name: this.Deployment, apiVersion: this.ApiVersion)),
-                Status = new V2beta2HorizontalPodAutoscalerStatus(currentReplicas: this.CurrentReplicas, desiredReplicas: this.MaxReplicas),
+                Spec = new V2HorizontalPodAutoscalerSpec(maxReplicas: this.MaxReplicas, minReplicas: this.MinReplicas, scaleTargetRef: new V2CrossVersionObjectReference(kind: "Deployment", name: this.Deployment, apiVersion: this.ApiVersion)),
+                Status = new V2HorizontalPodAutoscalerStatus(currentReplicas: this.CurrentReplicas, desiredReplicas: this.MaxReplicas),
             };
         }
 

--- a/burstsvc/burst.tests/Helper/K8sExtensions.cs
+++ b/burstsvc/burst.tests/Helper/K8sExtensions.cs
@@ -9,9 +9,9 @@ namespace Burst.Tests.Helper
 {
     internal static class K8sExtensions
     {
-        public static V2beta2HorizontalPodAutoscalerList ListHorizontalPodAutoscalerForAllNamespaces3(this IKubernetes ik8s, int timeoutSeconds = 1)
+        public static V2HorizontalPodAutoscalerList ListHorizontalPodAutoscalerForAllNamespaces3(this IKubernetes ik8s, int timeoutSeconds = 1)
         {
-            V2beta2HorizontalPodAutoscalerList hpaList = new();
+            V2HorizontalPodAutoscalerList hpaList = new();
             var hpaEssentials = HPAEssentials.GenerateHPAEssentials();
             foreach (var hpa in hpaEssentials)
             {
@@ -20,11 +20,5 @@ namespace Burst.Tests.Helper
 
             return hpaList;
         }
-
-        // public static V1Deployment ReadNamespacedDeployment(string name, string @namespace)
-        // {
-        //     var v1spec = new V1DeploymentSpec()
-        //     var v1Depl = new V1Deployment();
-        // }
     }
 }

--- a/burstsvc/burst.tests/Ngsa.BurstService.Test.csproj
+++ b/burstsvc/burst.tests/Ngsa.BurstService.Test.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="7.0.13" />
+    <PackageReference Include="KubernetesClient" Version="8.0.12" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/burstsvc/burst.tests/Ngsa.BurstService.Test.csproj
+++ b/burstsvc/burst.tests/Ngsa.BurstService.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <AssemblyName>burstservice.tests</AssemblyName>

--- a/burstsvc/burst.tests/UnitTests/HPAExtensionTest.cs
+++ b/burstsvc/burst.tests/UnitTests/HPAExtensionTest.cs
@@ -45,7 +45,7 @@ namespace Burst.Tests.UnitTests
                     && expectedMetrics.Service == metrics.Service);
             }
 
-            V2beta2HorizontalPodAutoscaler nullHpa = null;
+            V2HorizontalPodAutoscaler nullHpa = null;
             Assert.Null(nullHpa.ToHPAMetrics(0.0));
         }
 
@@ -70,7 +70,7 @@ namespace Burst.Tests.UnitTests
                 Assert.Equal(hpa.CurrentReplicas, currentLoad);
             }
 
-            V2beta2HorizontalPodAutoscaler nullHpa = null;
+            V2HorizontalPodAutoscaler nullHpa = null;
             Assert.Throws<Exception>(() => nullHpa.GetCurrentLoad());
 
             var mockHpa2 = fakeHPAList[0].CreateMockHPA();
@@ -99,7 +99,7 @@ namespace Burst.Tests.UnitTests
                 Assert.Equal(hpa.MaxReplicas, maxLoad);
             }
 
-            V2beta2HorizontalPodAutoscaler nullHpa = null;
+            V2HorizontalPodAutoscaler nullHpa = null;
             Assert.Throws<Exception>(() => nullHpa.GetMaxLoad());
             var anotherMock = fakeHPAList[0].CreateMockHPA();
             anotherMock.Spec = null;

--- a/burstsvc/burst/Dockerfile
+++ b/burstsvc/burst/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_ENV=
 ### Build and Test the App
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 
 ### copy the source and tests
 COPY burst/ /src/burst/
@@ -22,7 +22,7 @@ RUN dotnet publish -c Release -o /app
 
 
 ### Build the runtime container
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS release
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS release
 
 ### if port is changed, also update value in Config
 EXPOSE 8080

--- a/burstsvc/burst/Ngsa.BurstService.csproj
+++ b/burstsvc/burst/Ngsa.BurstService.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="7.0.11" />
+    <PackageReference Include="KubernetesClient" Version="8.0.12" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />

--- a/burstsvc/burst/Ngsa.BurstService.csproj
+++ b/burstsvc/burst/Ngsa.BurstService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Ngsa.BurstService</RootNamespace>
     <AssemblyName>burstservice</AssemblyName>
     <VersionPrefix>0.5.0</VersionPrefix>
@@ -47,7 +47,7 @@
   <ItemGroup>
     <PackageReference Include="KubernetesClient" Version="8.0.12" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
@@ -58,8 +58,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="6.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUi" Version="6.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/burstsvc/burst/Ngsa.BurstService.csproj
+++ b/burstsvc/burst/Ngsa.BurstService.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="KubernetesClient" Version="8.0.12" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
     <PackageReference Include="Microsoft.CorrelationVector" Version="1.0.42" />

--- a/burstsvc/burst/appsettings.json
+++ b/burstsvc/burst/appsettings.json
@@ -8,7 +8,7 @@
     }
   },
   "Service": {
-    "TargetScaleObj": "Deployment", // Other possible values: HPA, Service. But those are not supported yet
+    "TargetScaleObj": "Deployment", // Other possible values: HPA, Service
     "SelectorLabel" : ["app"] // e,g ["app", "kitt_deploy", "other-label-key"]
   }
 }

--- a/burstsvc/burst/src/Controllers/BurstMetricsController.cs
+++ b/burstsvc/burst/src/Controllers/BurstMetricsController.cs
@@ -40,17 +40,12 @@ namespace Ngsa.BurstService.Controllers
             K8sHPAMetrics hpaMetrics = service.GetK8SHPAMetrics(target, ns, name);
 
             // Nullable interpolation will return "" for null objects
-            // string cpuTarget = $"{hpaMetrics?.TargetCPULoad}";
-            // string cpuCurrent = $"{hpaMetrics?.CurrentCPULoad}";
-            // But we can control what to output if we do null
-
             if (hpaMetrics == null)
             {
                 // Means we don't have all the values available
                 return NoContent();
             }
 
-            // Console.WriteLine($"{DateTime.Now:s}  {Request.Path.ToString()}");
             return Ok(hpaMetrics.ToString());
         }
     }

--- a/burstsvc/burst/src/HealthChecks/CosmosHealthCheck.cs
+++ b/burstsvc/burst/src/HealthChecks/CosmosHealthCheck.cs
@@ -19,6 +19,11 @@ namespace Ngsa.BurstService
     /// </summary>
     public partial class CosmosHealthCheck : IHealthCheck
     {
+        /// <summary>
+        /// Represents the Name of Message atttribute utilizes for logging.
+        /// It is utilized as 'format string' in the message template format.
+        /// </summary>
+        public const string LoggerMessageAttributeName = "{message}";
         public static readonly string ServiceId = "ngsa";
         public static readonly string Description = "NGSA Health Check";
 
@@ -96,7 +101,7 @@ namespace Ngsa.BurstService
             catch (Exception ex)
             {
                 // log and return unhealthy
-                logger.LogError($"{ex}\nException:Healthz:{ex.Message}");
+                logger.LogError(LoggerMessageAttributeName, $"{ex}\nException:Healthz:{ex.Message}");
 
                 data.Add("Exception", ex.Message);
 

--- a/deploy/ngsa-memory/filter-gateway.yaml
+++ b/deploy/ngsa-memory/filter-gateway.yaml
@@ -35,16 +35,13 @@ spec:
           local:
            filename: /var/local/lib/wasm-filters/burst_header.wasm
         configuration:
-         "@type": "type.googleapis.com/google.protobuf.StringValue"
-         value: |
-          {
-            "service_cluster": "healthcluster",
-            "service_authority": "burst.burstservice",
-            "service_path": "/burstmetrics/services",
-            "user_agent": "HTTPie/",
-            "cache_seconds": 3
-          }               
-  # "user_agent": "EF-Strati-HealthCheck-Client/1.0",
+         "@type": "type.googleapis.com/google.protobuf.Struct"
+         value:
+            service_cluster: "healthcluster"
+            service_authority: "burst.burstservice"
+            service_path: "/burstmetrics/services"
+            cache_seconds: 3
+            user_agent: "HTTPie/"
 
   # The second patch adds the cluster that is referenced by the lua code
   # cds match is omitted as a new cluster is being added

--- a/deploy/ngsa-memory/filter-sidecar.yaml
+++ b/deploy/ngsa-memory/filter-sidecar.yaml
@@ -34,15 +34,13 @@ spec:
           local:
            filename: /var/local/lib/wasm-filters/burst_header.wasm
         configuration:
-         "@type": "type.googleapis.com/google.protobuf.StringValue"
-         value: |
-          {
-            "service_cluster": "healthcluster",
-            "service_authority": "burst.burstservice",
-            "service_path": "/burstmetrics/services",
-            "cache_seconds": 3
-          }               
-  # "user_agent": "EF-Strati-HealthCheck-Client/1.0",
+         "@type": "type.googleapis.com/google.protobuf.Struct"
+         value:
+            service_cluster: "healthcluster"
+            service_authority: "burst.burstservice"
+            service_path: "/burstmetrics/services"
+            cache_seconds: 5
+            user_agent: "HTTPie/"
 
   # The second patch adds the cluster that is referenced by the lua code
   # cds match is omitted as a new cluster is being added

--- a/deploy/prometheus/hpa-custom-metrics.yaml
+++ b/deploy/prometheus/hpa-custom-metrics.yaml
@@ -2,7 +2,7 @@
 # See docs specific to v1.22
 # https://v1-22.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/ 
 #######################################################
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: ngsa

--- a/spikes/grafana-tempo/ngsa-app/src/Controllers/DataService.cs
+++ b/spikes/grafana-tempo/ngsa-app/src/Controllers/DataService.cs
@@ -23,7 +23,7 @@ namespace Ngsa.Application.Controllers
         // json serialization options
         private static readonly JsonSerializerOptions Options = new ()
         {
-            IgnoreNullValues = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         };
 

--- a/spikes/grafana-tempo/ngsa-app/src/Core/NgsaLog.cs
+++ b/spikes/grafana-tempo/ngsa-app/src/Core/NgsaLog.cs
@@ -17,7 +17,7 @@ namespace Ngsa.Middleware
 
         private static readonly JsonSerializerOptions Options = new ()
         {
-            IgnoreNullValues = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };
 
         public static LogLevel LogLevel { get; set; } = LogLevel.Information;

--- a/spikes/grafana-tempo/ngsa-app/src/Core/Startup.cs
+++ b/spikes/grafana-tempo/ngsa-app/src/Core/Startup.cs
@@ -179,7 +179,7 @@ namespace Ngsa.Application
             services.AddControllers()
                 .AddJsonOptions(options =>
                 {
-                    options.JsonSerializerOptions.IgnoreNullValues = true;
+                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
                     options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
                     options.JsonSerializerOptions.DictionaryKeyPolicy = JsonNamingPolicy.CamelCase;
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());

--- a/spikes/grafana-tempo/ngsa-app/src/DataAccessLayer/CosmosConfig.cs
+++ b/spikes/grafana-tempo/ngsa-app/src/DataAccessLayer/CosmosConfig.cs
@@ -57,7 +57,7 @@ namespace Ngsa.Application.DataAccessLayer
                         MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(Timeout),
                         SerializerOptions = new CosmosSerializationOptions()
                         {
-                            IgnoreNullValues = true,
+                            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                             Indented = false,
                             PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase,
                         },

--- a/spikes/grafana-tempo/ngsa-app/src/HealthChecks/CosmosHealthCheck.cs
+++ b/spikes/grafana-tempo/ngsa-app/src/HealthChecks/CosmosHealthCheck.cs
@@ -46,8 +46,8 @@ namespace Ngsa.Application
                 // ignore nulls in json
                 jsonOptions = new JsonSerializerOptions
                 {
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    IgnoreNullValues = true,
                     DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
                 };
 

--- a/spikes/header-routing/deploy/kiali.yaml
+++ b/spikes/header-routing/deploy/kiali.yaml
@@ -50,7 +50,7 @@ data:
       custom_secrets: []
       host_aliases: []
       hpa:
-        api_version: autoscaling/v2beta2
+        api_version: autoscaling/v2
         spec: {}
       image_digest: ""
       image_name: quay.io/kiali/kiali

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,127 @@
+use protobuf::well_known_types::{Struct as ProtoStruct, Value};
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::rc::Rc;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub struct FilterConfig {
+    /// constant header, set at configmap
+    pub burst_header: Rc<String>,
+
+    /// Cache duration in seconds
+    pub cache_seconds: Duration,
+
+    /// The authority to set when calling the HTTP service providing headers.
+    pub service_authority: Rc<String>,
+
+    /// The Envoy cluster name
+    pub service_cluster: Rc<String>,
+
+    /// The path to call on the HTTP service providing headers.
+    pub service_path: Rc<String>,
+
+    /// user agent
+    pub user_agent: Rc<String>,
+}
+
+#[derive(Debug)]
+pub enum FilterConfigError {
+    Missing,
+    Format(String),
+}
+
+impl Display for FilterConfigError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FilterConfigError::Missing => {
+                write!(f, "Filter Config Missing")
+            }
+            FilterConfigError::Format(s) => {
+                write!(f, "Format: {}", s.as_str())
+            }
+        }
+    }
+}
+
+impl Error for FilterConfigError {}
+
+impl TryFrom<ProtoStruct> for FilterConfig {
+    type Error = FilterConfigError;
+
+    fn try_from(mut value: ProtoStruct) -> Result<Self, Self::Error> {
+        let mut fields = value.take_fields();
+
+        let burst_header = take_string_field(&mut fields, "burst_header")?;
+        let service_cluster = take_string_field(&mut fields, "service_cluster")?;
+        let service_path = take_string_field(&mut fields, "service_path")?;
+
+        let user_agent = take_string_field(&mut fields, "user_agent")?;
+        let service_authority = take_string_field(&mut fields, "service_authority")?;
+
+        let cache_duration = take_duration_field(&mut fields, "cache_seconds")?
+            .unwrap_or(Duration::from_secs(60));
+
+        Ok(FilterConfig {
+            cache_seconds: cache_duration,
+            burst_header: Rc::new(burst_header),
+            service_authority: Rc::new(service_authority),
+            service_cluster: Rc::new(service_cluster),
+            service_path: Rc::new(service_path),
+            user_agent: Rc::new(user_agent),
+        })
+    }
+}
+
+fn take_string_field(
+    fields: &mut HashMap<String, Value>,
+    key: &str,
+) -> Result<String, FilterConfigError> {
+    let v = fields.remove(key).map(|mut v| {
+        if v.has_null_value() {
+            Ok(String::new())
+        } else if v.has_string_value() {
+            Ok(v.take_string_value())
+        } else {
+            Err(FilterConfigError::Format(format!(
+                "{} is not a string",
+                key
+            )))
+        }
+    });
+
+    match v {
+        None => Ok(String::new()),
+        Some(Ok(s)) => Ok(s),
+        Some(Err(e)) => Err(e),
+    }
+}
+
+fn take_duration_field(
+    fields: &mut HashMap<String, Value>,
+    key: &str,
+) -> Result<Option<Duration>, FilterConfigError> {
+    let v = fields.remove(key).map(|v| {
+        if v.has_number_value() {
+            Ok(v.get_number_value())
+        } else {
+            Err(FilterConfigError::Format(format!(
+                "{} is not a duration",
+                key
+            )))
+        }
+    });
+
+    match v {
+        None => Ok(None),
+        Some(Ok(d)) if d.is_sign_negative() => Err(FilterConfigError::Format(format!(
+            "{} is not a duration, since it has a negative value",
+            key
+        ))),
+        Some(Ok(d)) => Ok(Some(Duration::from_secs(d as u64))),
+        Some(Err(e)) => Err(e),
+    }
+}

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -3,9 +3,12 @@
 #[path="../src/lib.rs"]
 mod burst_header;
 
-use burst_header::FilterConfig ;
+#[path="../src/config.rs"]
+mod config;
+
 use wasm_bindgen_test::*;
 
+// upstream bug in proxy_wasm::*, currently errors out
 #[wasm_bindgen_test]
 fn it_works() {
     assert_eq!(2 + 2, 4);


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Add config parameter validation in WASM code
Update to use v2 HPA api, v2beta2 is deprecated from K8S API v1.23.0 and beyond
Other todo cleanup

## Does this introduce a breaking change

- [x] YES
- [ ] NO

WASM config should now be passed as a Struct object instead of a JSON string (see filter-*.yaml file changes for an example)

## Validation

- [x] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/751
