### PR TITLE
Handle empty burstmetrics, user agent in wasm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ impl RootHandler {
     pub(crate) fn new() -> Self {
         Self {
             config: None,
-            cluster_map: None,
+            cluster_map: Some(Map::new()),
         }
     }
 }
@@ -213,12 +213,14 @@ impl Context for RequestContext {}
 impl HttpContext for RequestContext {
     // check headers for user-agent match and store in self
     fn on_http_request_headers(&mut self, _: usize) -> Action {
-        if self
+        self.add_header = true;
+        if !self.user_agent.as_str().is_empty() &&
+            !self
             .get_http_request_header(USER_AGENT)
             .unwrap_or_default()
             .starts_with(self.user_agent.as_str())
         {
-            self.add_header = true;
+            self.add_header = false;
         } else {
             debug!("Not adding header. User agent mismatch");
         }


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Handle following edge cases in wasm code
 - empty response from burst metrics service
 - user agent is empty 

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Issues Closed or Referenced

- References https://github.com/retaildevcrews/wcnp/issues/967
