### PR TITLE
Replaced deprecated Rust plugin with Rust-Analyzer plugin

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,7 @@
 		"gruntfuggly.todo-tree",
 		"ms-azuretools.vscode-docker",
 		"mutantdino.resourcemonitor",
-		"rust-lang.rust",
+		"rust-lang.rust-analyzer",
 		"vadimcn.vscode-lldb",
 		"humao.rest-client",
 		"serayuzgur.crates",


### PR DESCRIPTION
## Purpose of PR

Remove deprecated Rust Extension

The [Rust extension](https://github.com/rust-lang/vscode-rust) we're using in our Codespace is deprecated and hasn't receive any updates for over 2 years.

We should move to [Rust-Analyzer](https://github.com/rust-lang/rust-analyzer) which is the current de-facto extension for Rust development.

See the comments on [deprecation notice](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust&ssr=false#review-details)

Also, VSCode documentation suggests using [Rust-Analyzer as default extension](https://code.visualstudio.com/docs/languages/rust)

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [ ] Tested with Codespaces

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/985